### PR TITLE
use esbuild `publicPath` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ interface HtmlFileConfiguration {
 }
 ```
 
+In case a `publicPath` is specified in the esbuild configuration,
+`esbuild-plugin-html` will use absolute paths with the provided `publicPath`.
+
 You can also change the verbosity of the plugin by changing esbuild's verbosity.
 
 #### Default HTML template

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -90,16 +90,17 @@ const htmlPlugin = (configuration = { files: [], }) => {
         const compiledTemplateFn = (0, lodash_template_1.default)(htmlTemplate);
         return compiledTemplateFn(templateContext);
     }
-    function injectFiles(dom, assets, outDir, htmlFileConfiguration) {
+    function injectFiles(dom, assets, outDir, publicPath, htmlFileConfiguration) {
         const document = dom.window.document;
         for (const outputFile of assets) {
             const filepath = outputFile.path;
             const out = path_1.default.join(outDir, htmlFileConfiguration.filename);
             const relativePath = path_1.default.relative(path_1.default.dirname(out), filepath);
+            const absolutePath = publicPath + relativePath;
             const ext = path_1.default.parse(filepath).ext;
             if (ext === '.js') {
                 const scriptTag = document.createElement('script');
-                scriptTag.setAttribute('src', relativePath);
+                scriptTag.setAttribute('src', absolutePath);
                 if (htmlFileConfiguration.scriptLoading === 'module') {
                     // If module, add type="module"
                     scriptTag.setAttribute('type', 'module');
@@ -113,11 +114,11 @@ const htmlPlugin = (configuration = { files: [], }) => {
             else if (ext === '.css') {
                 const linkTag = document.createElement('link');
                 linkTag.setAttribute('rel', 'stylesheet');
-                linkTag.setAttribute('href', relativePath);
+                linkTag.setAttribute('href', absolutePath);
                 document.head.appendChild(linkTag);
             }
             else {
-                logInfo && console.log(`Warning: found file ${relativePath}, but it was neither .js nor .css`);
+                logInfo && console.log(`Warning: found file ${absolutePath}, but it was neither .js nor .css`);
             }
         }
     }
@@ -133,6 +134,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 }
             });
             build.onEnd(async (result) => {
+                var _a;
                 const startTime = Date.now();
                 if (build.initialOptions.logLevel == 'debug' || build.initialOptions.logLevel == 'info') {
                     logInfo = true;
@@ -153,6 +155,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                     // Note: we can safely disable this rule here, as we already asserted this in setup.onStart
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     const outdir = build.initialOptions.outdir;
+                    const publicPath = (_a = build.initialOptions.publicPath) !== null && _a !== void 0 ? _a : "";
                     const htmlTemplate = htmlFileConfiguration.htmlTemplate || defaultHtmlTemplate;
                     const templatingResult = renderTemplate(htmlFileConfiguration, htmlTemplate);
                     // Next, we insert the found files into the htmlTemplate - if no htmlTemplate was specified, we default to a basic one.
@@ -170,7 +173,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                         linkTag.setAttribute('href', '/favicon.ico');
                         document.head.appendChild(linkTag);
                     }
-                    injectFiles(dom, collectedOutputFiles, outdir, htmlFileConfiguration);
+                    injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration);
                     const out = path_1.default.join(outdir, htmlFileConfiguration.filename);
                     await fs_1.promises.writeFile(out, dom.serialize());
                     const stat = await fs_1.promises.stat(out);

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -8,6 +8,7 @@ const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
 const jsdom_1 = require("jsdom");
 const lodash_template_1 = __importDefault(require("lodash.template"));
+const urlcat_1 = __importDefault(require("urlcat"));
 const defaultHtmlTemplate = `
 <!DOCTYPE html>
 <html>
@@ -94,13 +95,18 @@ const htmlPlugin = (configuration = { files: [], }) => {
         const document = dom.window.document;
         for (const outputFile of assets) {
             const filepath = outputFile.path;
-            const out = path_1.default.join(outDir, htmlFileConfiguration.filename);
-            const relativePath = path_1.default.relative(path_1.default.dirname(out), filepath);
-            const absolutePath = publicPath + relativePath;
+            let targetPath;
+            if (publicPath) {
+                targetPath = (0, urlcat_1.default)(publicPath, path_1.default.relative(outDir, filepath));
+            }
+            else {
+                const htmlFileDirectory = path_1.default.join(outDir, htmlFileConfiguration.filename);
+                targetPath = path_1.default.relative(path_1.default.dirname(htmlFileDirectory), filepath);
+            }
             const ext = path_1.default.parse(filepath).ext;
             if (ext === '.js') {
                 const scriptTag = document.createElement('script');
-                scriptTag.setAttribute('src', absolutePath);
+                scriptTag.setAttribute('src', targetPath);
                 if (htmlFileConfiguration.scriptLoading === 'module') {
                     // If module, add type="module"
                     scriptTag.setAttribute('type', 'module');
@@ -114,11 +120,11 @@ const htmlPlugin = (configuration = { files: [], }) => {
             else if (ext === '.css') {
                 const linkTag = document.createElement('link');
                 linkTag.setAttribute('rel', 'stylesheet');
-                linkTag.setAttribute('href', absolutePath);
+                linkTag.setAttribute('href', targetPath);
                 document.head.appendChild(linkTag);
             }
             else {
-                logInfo && console.log(`Warning: found file ${absolutePath}, but it was neither .js nor .css`);
+                logInfo && console.log(`Warning: found file ${targetPath}, but it was neither .js nor .css`);
             }
         }
     }
@@ -134,7 +140,6 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 }
             });
             build.onEnd(async (result) => {
-                var _a;
                 const startTime = Date.now();
                 if (build.initialOptions.logLevel == 'debug' || build.initialOptions.logLevel == 'info') {
                     logInfo = true;
@@ -155,7 +160,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                     // Note: we can safely disable this rule here, as we already asserted this in setup.onStart
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     const outdir = build.initialOptions.outdir;
-                    const publicPath = (_a = build.initialOptions.publicPath) !== null && _a !== void 0 ? _a : "";
+                    const publicPath = build.initialOptions.publicPath;
                     const htmlTemplate = htmlFileConfiguration.htmlTemplate || defaultHtmlTemplate;
                     const templatingResult = renderTemplate(htmlFileConfiguration, htmlTemplate);
                     // Next, we insert the found files into the htmlTemplate - if no htmlTemplate was specified, we default to a basic one.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "jsdom": "^17.0.0",
-    "lodash.template": "^4.5.0"
+    "lodash.template": "^4.5.0",
+    "urlcat": "^2.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,10 +845,30 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lodash._reinterpolate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.template@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
+  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
+    lodash.templatesettings "^4.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
+  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -869,26 +889,6 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
-
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
 
 mime-db@1.49.0:
   version "1.49.0"
@@ -1181,6 +1181,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+urlcat@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/urlcat/-/urlcat-2.0.4.tgz#c119b4e3b31df4d140e77e177ea5d95dbe6b2fe2"
+  integrity sha512-12c4Vi40DHVdZ/8mOLjZjp0asCzM6hi8Gj116fpImRP1FN4gBMCtMi9XhLNOmre/FEQYNqHbZmX8iyYAtIcy8Q==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
This feature allows to prepend publicPath if specified in build options of esbuild.
For example, with following configuration:
```js
esbuild.build({
  ...,
  publicPath: "http://example.com/",
  plugins: [
    htmlPlugin({/* options to html plugin is not changed */}),
  ].
  ...
})
```
I get like this:
```
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8" />
  </head>
  <body>
    <script src="http://example.com/bundle.js" defer=""></script>
  </body>
</html>
```