### PR TITLE
/ as publicPath

### DIFF
--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -97,7 +97,9 @@ const htmlPlugin = (configuration = { files: [], }) => {
             const filepath = outputFile.path;
             let targetPath;
             if (publicPath) {
-                targetPath = (0, urlcat_1.default)(publicPath, path_1.default.relative(outDir, filepath));
+                targetPath = publicPath === '/'
+                    ? path_1.default.join(publicPath, path_1.default.relative(outDir, filepath))
+                    : (0, urlcat_1.default)(publicPath, path_1.default.relative(outDir, filepath));
             }
             else {
                 const htmlFileDirectory = path_1.default.join(outDir, htmlFileConfiguration.filename);

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,9 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
             let targetPath: string
             if (publicPath) {
-                targetPath = urlcat(publicPath, path.relative(outDir, filepath))
+                targetPath = publicPath === '/' 
+                    ? path.join(publicPath, path.relative(outDir, filepath)) 
+                    : urlcat(publicPath, path.relative(outDir, filepath))
             } else {
                 const htmlFileDirectory = path.join(outDir, htmlFileConfiguration.filename)
                 targetPath = path.relative(path.dirname(htmlFileDirectory), filepath)


### PR DESCRIPTION
- Allows publicPath to simply be `/`
- Current solution doesn't play well with React Router/Express
- Navigating to`/categories` for example attempts to load `/categories/index.js` & `/categories/index.css` instead of `/index.js` and `/index.css`