### PR TITLE
fix: replacing all usages of path.join with posixJoin (#29)

### DIFF
--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -23,6 +23,14 @@ const REGEXES = {
     HASH_REGEX: '(?<hash>[A-Z2-7]{8})',
     NAME_REGEX: '(?<name>[^\\s\\/]+)',
 };
+// This function joins a path, and in case of windows, it converts backward slashes ('\') forward slashes ('/').
+function posixJoin(...paths) {
+    const joined = path_1.default.join(...paths);
+    if (path_1.default.sep === '/') {
+        return joined;
+    }
+    return joined.split(path_1.default.sep).join(path_1.default.posix.sep);
+}
 function escapeRegExp(text) {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
@@ -53,7 +61,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
             // We therefore try to extract the dir, name and hash from the "main"-output, and try to find all files with
             // the same [name] and [dir].
             // This should always include the "main"-output, as well as all relatedOutputs
-            const joinedPathOfMatch = path_1.default.join(pathOfMatchedOutput.dir, pathOfMatchedOutput.name);
+            const joinedPathOfMatch = posixJoin(pathOfMatchedOutput.dir, pathOfMatchedOutput.name);
             const findVariablesRegexString = escapeRegExp(entryNames)
                 .replace('\\[hash\\]', REGEXES.HASH_REGEX)
                 .replace('\\[name\\]', REGEXES.NAME_REGEX)
@@ -115,7 +123,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 targetPath = joinWithPublicPath(publicPath, path_1.default.relative(outDir, filepath));
             }
             else {
-                const htmlFileDirectory = path_1.default.join(outDir, htmlFileConfiguration.filename);
+                const htmlFileDirectory = posixJoin(outDir, htmlFileConfiguration.filename);
                 targetPath = path_1.default.relative(path_1.default.dirname(htmlFileDirectory), filepath);
             }
             const ext = path_1.default.parse(filepath).ext;
@@ -200,7 +208,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                         document.head.appendChild(linkTag);
                     }
                     injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration);
-                    const out = path_1.default.join(outdir, htmlFileConfiguration.filename);
+                    const out = posixJoin(outdir, htmlFileConfiguration.filename);
                     await fs_1.promises.mkdir(path_1.default.dirname(out), {
                         recursive: true,
                     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,15 @@ const REGEXES = {
     NAME_REGEX: '(?<name>[^\\s\\/]+)',
 }
 
+// This function joins a path, and in case of windows, it converts backward slashes ('\') forward slashes ('/').
+function posixJoin(...paths: string[]): string {
+    const joined = path.join(...paths)
+    if (path.sep === '/') {
+        return joined
+    }
+    return joined.split(path.sep).join(path.posix.sep)
+}
+
 function escapeRegExp(text: string): string {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
 }
@@ -71,7 +80,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
             // We therefore try to extract the dir, name and hash from the "main"-output, and try to find all files with
             // the same [name] and [dir].
             // This should always include the "main"-output, as well as all relatedOutputs
-            const joinedPathOfMatch = path.join(pathOfMatchedOutput.dir, pathOfMatchedOutput.name)
+            const joinedPathOfMatch = posixJoin(pathOfMatchedOutput.dir, pathOfMatchedOutput.name)
             const findVariablesRegexString = escapeRegExp(entryNames)
                 .replace('\\[hash\\]', REGEXES.HASH_REGEX)
                 .replace('\\[name\\]', REGEXES.NAME_REGEX)
@@ -140,7 +149,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
             if (publicPath) {
                 targetPath = joinWithPublicPath(publicPath, path.relative(outDir, filepath))
             } else {
-                const htmlFileDirectory = path.join(outDir, htmlFileConfiguration.filename)
+                const htmlFileDirectory = posixJoin(outDir, htmlFileConfiguration.filename)
                 targetPath = path.relative(path.dirname(htmlFileDirectory), filepath)
             }
             const ext = path.parse(filepath).ext
@@ -238,7 +247,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
                     injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration)
 
-                    const out = path.join(outdir, htmlFileConfiguration.filename)
+                    const out = posixJoin(outdir, htmlFileConfiguration.filename)
                     await fs.mkdir(path.dirname(out), {
                         recursive: true,
                     })


### PR DESCRIPTION
posixJoin will hopefully join paths correctly on windows.

Fixes #29.