### PR TITLE
Extra Script Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ interface HtmlFileConfiguration {
     findRelatedOutputFiles?: boolean,
                                 // Find related output (*.css)-files and inject them into the html. 
                                 // Defaults to true.
+    extraScripts?: (string | {  // accepts an array of src strings or objects with src and attributes
+        src: string;            // src to use for the script
+        tags?: (string | { key: string; value: string })[] // array of tags to append to the script, if a string, the value defaults to ""
+    })[]
 }
 ```
 

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -11,5 +11,12 @@ export interface HtmlFileConfiguration {
     scriptLoading?: 'blocking' | 'defer' | 'module';
     favicon?: string;
     findRelatedOutputFiles?: boolean;
+    extraScripts?: (string | {
+        src: string;
+        tags: (string | {
+            key: string;
+            value: string;
+        })[];
+    })[];
 }
 export declare const htmlPlugin: (configuration?: Configuration) => esbuild.Plugin;

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -13,7 +13,7 @@ export interface HtmlFileConfiguration {
     findRelatedOutputFiles?: boolean;
     extraScripts?: (string | {
         src: string;
-        tags: (string | {
+        tags?: (string | {
             key: string;
             value: string;
         })[];

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -214,7 +214,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                         }
                         else {
                             scriptTag.setAttribute('src', script.src);
-                            for (const tag of script.tags) {
+                            for (const tag of (script === null || script === void 0 ? void 0 : script.tags) || []) {
                                 if (typeof tag === 'string') {
                                     scriptTag.setAttribute(tag, '');
                                 }

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -207,6 +207,24 @@ const htmlPlugin = (configuration = { files: [], }) => {
                         linkTag.setAttribute('href', '/favicon.ico');
                         document.head.appendChild(linkTag);
                     }
+                    for (const script of (htmlFileConfiguration === null || htmlFileConfiguration === void 0 ? void 0 : htmlFileConfiguration.extraScripts) || []) {
+                        const scriptTag = document.createElement('script');
+                        if (typeof script === 'string') {
+                            scriptTag.setAttribute('src', script);
+                        }
+                        else {
+                            scriptTag.setAttribute('src', script.src);
+                            for (const tag of script.tags) {
+                                if (typeof tag === 'string') {
+                                    scriptTag.setAttribute(tag, '');
+                                }
+                                else {
+                                    scriptTag.setAttribute(tag.key, tag.value);
+                                }
+                            }
+                        }
+                        document.body.append(scriptTag);
+                    }
                     injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration);
                     const out = posixJoin(outdir, htmlFileConfiguration.filename);
                     await fs_1.promises.mkdir(path_1.default.dirname(out), {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ export interface HtmlFileConfiguration {
     scriptLoading?: 'blocking' | 'defer' | 'module',
     favicon?: string,
     findRelatedOutputFiles?: boolean,
+    extraScripts?: (string | { 
+        src: string; 
+        tags: (string | { key: string; value: string })[] 
+    })[]
 }
 
 const defaultHtmlTemplate = `
@@ -245,6 +249,22 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
                         document.head.appendChild(linkTag)
                     }
 
+                    for (const script of htmlFileConfiguration?.extraScripts || []) {
+                        const scriptTag = document.createElement('script')
+                        if (typeof script === 'string') {
+                            scriptTag.setAttribute('src', script)
+                        } else {
+                            scriptTag.setAttribute('src', script.src)
+                            for (const tag of script.tags) {
+                                if (typeof tag === 'string') {
+                                    scriptTag.setAttribute(tag, '')
+                                } else {
+                                    scriptTag.setAttribute(tag.key, tag.value)
+                                }
+                            }
+                        }
+                        document.body.append(scriptTag)
+                    }
                     injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration)
 
                     const out = posixJoin(outdir, htmlFileConfiguration.filename)

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export interface HtmlFileConfiguration {
     findRelatedOutputFiles?: boolean,
     extraScripts?: (string | { 
         src: string; 
-        tags: (string | { key: string; value: string })[] 
+        tags?: (string | { key: string; value: string })[] 
     })[]
 }
 
@@ -255,7 +255,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
                             scriptTag.setAttribute('src', script)
                         } else {
                             scriptTag.setAttribute('src', script.src)
-                            for (const tag of script.tags) {
+                            for (const tag of script?.tags || []) {
                                 if (typeof tag === 'string') {
                                     scriptTag.setAttribute(tag, '')
                                 } else {


### PR DESCRIPTION
This PR may either be too obscure, and if so, I'm fine to write a separate plugin to handle this separately. Or this might already be possible with existing functions and it just wasn't clear to me. Either way, no worries if you don't want to accept this! I just happen to need to inject an extra script when compiling dev environment but not production.

- `extraScripts` array accepts either an array of src strings or an array of objects to further customize the script. 
- If an object, it also accepts an array of tags to append, which can optionally be strings or an object of keys, values. If a string, the value defaults to `""`