### PR TITLE
Feature: option to inline js and css files

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ interface HtmlFileConfiguration {
                                 // like (*.css)-files and inject them into the html. This option is deprecated,
                                 // consider using findRelatedCssFiles.
                                 // Defaults to false.
+    inline?: boolean | {        // Inline all js and css entry points into the html file.
+        js?: boolean,           // Inline all js resources into the html file. 
+        css?: boolean,          // Inline all css resources into the html file.
+    }                           // Not set by default - will not inline any resources.
     extraScripts?: (string | {  // accepts an array of src strings or objects with src and attributes
         src: string;            // src to use for the script
         attrs?: { [key: string]: string } // attributes to append to the script, e.g. { type: 'module', async: true }

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -1,17 +1,34 @@
-import esbuild from 'esbuild';
+import esbuild from 'esbuild'
 export interface Configuration {
     files: HtmlFileConfiguration[];
 }
 export interface HtmlFileConfiguration {
+    /** @param filename The name of the output HTML file (relative to the output directory) */
     filename: string;
+    /** @param entryPoints The entry points to include in the HTML file. */
     entryPoints: string[];
+    /** @param title The title of the HTML file. */
     title?: string;
+    /** @param htmlTemplate A path to a custom HTML template to use. If not set, a default template will be used. */
     htmlTemplate?: string;
+    /** @param define A map of variables that will be available in the HTML file. */
     define?: Record<string, string>;
+    /** @param scriptLoading How to load the generated script tags: blocking, defer, or module. Defaults to defer. */
     scriptLoading?: 'blocking' | 'defer' | 'module';
+    /** @param favicon A path to a favicon to use. */
     favicon?: string;
+    /** @param findRelatedCssFiles Whether to find CSS files that are related to the entry points. */
     findRelatedCssFiles?: boolean;
+    /**
+     * @deprecated Use findRelatedCssFiles instead.
+     * @param findRelatedOutputFiles Whether to find output files that are related to the entry points. */
     findRelatedOutputFiles?: boolean;
+    /** @param inline Whether to inline the content of the js and css files. */
+    inline?: boolean | {
+        css?: boolean;
+        js?: boolean;
+    };
+    /** @param extraScripts Extra script tags to include in the HTML file. */
     extraScripts?: (string | {
         src: string;
         attrs?: {
@@ -19,4 +36,4 @@ export interface HtmlFileConfiguration {
         };
     })[];
 }
-export declare const htmlPlugin: (configuration?: Configuration) => esbuild.Plugin;
+export declare const htmlPlugin: (configuration?: Configuration) => esbuild.Plugin

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -72,7 +72,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
             const dir = (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b['dir'];
             return Object.entries((metafile === null || metafile === void 0 ? void 0 : metafile.outputs) || {}).filter(([pathOfCurrentOutput,]) => {
                 if (entryNames) {
-                    // if a entryName is set, we need to parse the output filename, get the name and dir, 
+                    // if a entryName is set, we need to parse the output filename, get the name and dir,
                     // and find files that match the same criteria
                     const findFilesWithSameVariablesRegexString = escapeRegExp(entryNames.replace('[name]', name !== null && name !== void 0 ? name : '').replace('[dir]', dir !== null && dir !== void 0 ? dir : ''))
                         .replace('\\[hash\\]', REGEXES.HASH_REGEX);
@@ -114,7 +114,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
         }
         return `${publicPath}${slash}${relPath}`;
     }
-    function injectFiles(dom, assets, outDir, publicPath, htmlFileConfiguration) {
+    async function injectFiles(dom, assets, outDir, publicPath, htmlFileConfiguration) {
         const document = dom.window.document;
         for (const script of (htmlFileConfiguration === null || htmlFileConfiguration === void 0 ? void 0 : htmlFileConfiguration.extraScripts) || []) {
             const scriptTag = document.createElement('script');
@@ -140,8 +140,29 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 targetPath = path_1.default.relative(path_1.default.dirname(htmlFileDirectory), filepath);
             }
             const ext = path_1.default.parse(filepath).ext;
+            // Inline the JavaScript and CSS files if the option is set.
+            const { inline } = htmlFileConfiguration;
+            const isInline = (inline_, ext_) => {
+                if (!inline_) {
+                    return false;
+                }
+                const extension = ext_.replace('.', '');
+                return ((typeof inline_ === 'boolean' && inline_ === true) ||
+                    (typeof inline_ === 'object' && inline_[extension] === true));
+            };
             if (ext === '.js') {
                 const scriptTag = document.createElement('script');
+                // Check if the JavaScript should be inlined.
+                if (isInline(inline, ext)) {
+                    console.log('Inlining script', filepath);
+                    // Read the content of the JavaScript file, then append to the script tag
+                    const scriptContent = await fs_1.default.promises.readFile(filepath, 'utf-8');
+                    scriptTag.textContent = scriptContent;
+                    document.body.append(scriptTag);
+                    // no need to set any attributes
+                    continue;
+                }
+                // If not inlined, set the 'src' attribute as usual.
                 scriptTag.setAttribute('src', targetPath);
                 if (htmlFileConfiguration.scriptLoading === 'module') {
                     // If module, add type="module"
@@ -154,6 +175,15 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 document.body.append(scriptTag);
             }
             else if (ext === '.css') {
+                // Check if the CSS should be inlined -> if so, use style tags instead of link tags.
+                if (isInline(inline, ext)) {
+                    const styleTag = document.createElement('style');
+                    const styleContent = await fs_1.default.promises.readFile(filepath, 'utf-8');
+                    styleTag.textContent = styleContent;
+                    document.head.append(styleTag);
+                    // no need to set any attributes
+                    continue;
+                }
                 const linkTag = document.createElement('link');
                 linkTag.setAttribute('rel', 'stylesheet');
                 linkTag.setAttribute('href', targetPath);
@@ -228,7 +258,7 @@ const htmlPlugin = (configuration = { files: [], }) => {
                         linkTag.setAttribute('href', faviconPublicPath);
                         document.head.appendChild(linkTag);
                     }
-                    injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration);
+                    await injectFiles(dom, collectedOutputFiles, outdir, publicPath, htmlFileConfiguration);
                     const out = posixJoin(outdir, htmlFileConfiguration.filename);
                     await fs_1.default.promises.mkdir(path_1.default.dirname(out), {
                         recursive: true,


### PR DESCRIPTION
I had to make a few small changes for my use case that bundled all resources into a single html file without external references, and thought it might be a useful option to others.

### Changes:

- added optional inline property to HTMLFileConfiguration.
-  modified injectFiles function to first check inline property before adding attributes/appending to body.
- injectFiles now async to allow fs.promises to be used for inlining.
- if  js file is inlined = true, the script tag will not have any attributes, only contents of the js file.
- if css file is inlined, the link tag is replaced with a style tag containing the contents of the css file.
- added JSDoc comments to HTMLFileConfiguration.
- updated README with inline option

**new inline property added to HTMLFileConfiguration:**
```
 inline?: boolean | { js?: boolean; css?: boolean }
```

### Examples

#### No inline for js (default):
```
<body>
    <div id="container"></div>
    <script src="index.js" defer=""></script>
</body>
```

#### inline js file:
```
<body>
    <div id="container"></div>
    <script>
        // index.js
        (() => {
            const content = "hi mom"
            document.getElementById("container").innerText = content
        })()
    </script>
</body>
```
#### No inline for css file (default)
```
<head>
    <link rel="stylesheet" href="style.css">
</head>
```
#### inline css file:
```
<head>
    <style>
        /* style.css */
        body {
            background-color: blue;
        }
    </style>
</head>
```