### PR TITLE
config: support `hash` option (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ const options = {
                     title: 'Login',
                     scriptLoading: 'module',
                     favicon: './public/favicon.ico',
+                    hash: true,
                 },
                 {
                     entryPoints: [
@@ -161,7 +162,8 @@ interface HtmlFileConfiguration {
     extraScripts?: (string | {  // accepts an array of src strings or objects with src and attributes
         src: string;            // src to use for the script
         attrs?: { [key: string]: string } // attributes to append to the script, e.g. { type: 'module', async: true }
-    })[]
+    })[],
+    hash: boolean               // If true, append a hash to all included scripts and CSS files for cache-busting.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ interface HtmlFileConfiguration {
         src: string;            // src to use for the script
         attrs?: { [key: string]: string } // attributes to append to the script, e.g. { type: 'module', async: true }
     })[],
-    hash: boolean               // If true, append a hash to all included scripts and CSS files for cache-busting.
+    hash?: boolean | string,    // Append a hash to all included scripts and CSS files for cache-busting. The
+                                // hash is based on the given string. If given a boolean, the hash is based on
+                                // the current time.
 }
 ```
 

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -18,5 +18,6 @@ export interface HtmlFileConfiguration {
             [key: string]: string;
         };
     })[];
+    hash: boolean;
 }
 export declare const htmlPlugin: (configuration?: Configuration) => esbuild.Plugin;

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -18,6 +18,6 @@ export interface HtmlFileConfiguration {
             [key: string]: string;
         };
     })[];
-    hash: boolean;
+    hash?: boolean | string;
 }
 export declare const htmlPlugin: (configuration?: Configuration) => esbuild.Plugin;

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -4,6 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.htmlPlugin = void 0;
+const crypto_1 = __importDefault(require("crypto"));
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const jsdom_1 = require("jsdom");
@@ -138,6 +139,9 @@ const htmlPlugin = (configuration = { files: [], }) => {
             else {
                 const htmlFileDirectory = posixJoin(outDir, htmlFileConfiguration.filename);
                 targetPath = path_1.default.relative(path_1.default.dirname(htmlFileDirectory), filepath);
+            }
+            if (htmlFileConfiguration.hash) {
+                targetPath = `${targetPath}?${crypto_1.default.createHash('md5').update(JSON.stringify(outputFile)).digest("hex")}`;
             }
             const ext = path_1.default.parse(filepath).ext;
             if (ext === '.js') {

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -141,7 +141,8 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 targetPath = path_1.default.relative(path_1.default.dirname(htmlFileDirectory), filepath);
             }
             if (htmlFileConfiguration.hash) {
-                targetPath = `${targetPath}?${crypto_1.default.createHash('md5').update(JSON.stringify(outputFile)).digest("hex")}`;
+                const hashableContents = htmlFileConfiguration.hash === true ? `${Date.now()}` : htmlFileConfiguration.hash;
+                targetPath = `${targetPath}?${crypto_1.default.createHash('md5').update(hashableContents).digest('hex')}`;
             }
             const ext = path_1.default.parse(filepath).ext;
             if (ext === '.js') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export interface HtmlFileConfiguration {
         src: string,
         attrs?: { [key: string]: string }
     })[],
-    hash: boolean
+    hash?: boolean | string,
 }
 
 const defaultHtmlTemplate = `
@@ -171,7 +171,8 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
                 targetPath = path.relative(path.dirname(htmlFileDirectory), filepath)
             }
             if (htmlFileConfiguration.hash) {
-                targetPath = `${targetPath}?${crypto.createHash('md5').update(JSON.stringify(outputFile)).digest("hex")}`;
+                const hashableContents = htmlFileConfiguration.hash === true ? `${Date.now()}` : htmlFileConfiguration.hash
+                targetPath = `${targetPath}?${crypto.createHash('md5').update(hashableContents).digest('hex')}`
             }
             const ext = path.parse(filepath).ext
             if (ext === '.js') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import esbuild from 'esbuild'
 import fs from 'fs'
 import path from 'path'
@@ -21,7 +22,8 @@ export interface HtmlFileConfiguration {
     extraScripts?: (string | {
         src: string,
         attrs?: { [key: string]: string }
-    })[]
+    })[],
+    hash: boolean
 }
 
 const defaultHtmlTemplate = `
@@ -167,6 +169,9 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
             } else {
                 const htmlFileDirectory = posixJoin(outDir, htmlFileConfiguration.filename)
                 targetPath = path.relative(path.dirname(htmlFileDirectory), filepath)
+            }
+            if (htmlFileConfiguration.hash) {
+                targetPath = `${targetPath}?${crypto.createHash('md5').update(JSON.stringify(outputFile)).digest("hex")}`;
             }
             const ext = path.parse(filepath).ext
             if (ext === '.js') {


### PR DESCRIPTION
Support a new option: `hash`
This will cause the appending of a hash based on the output's JSON metadata, so that upon new releases there is a cache-busting effect. [Similar to `html-webpack-plugin`'s `hash` option](https://github.com/jantimon/html-webpack-plugin#options).