### PR TITLE
config: add `injectedOutputs` option (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ const options = {
           `,
                 },
                 {
-                    entryPoints: [
-                        'src/auth/auth.jsx',
+                    injectedOutputs: [
+                        'dist/auth.js',
                     ],
                     filename: 'auth.html',
                     title: 'Login',
@@ -138,8 +138,10 @@ interface Configuration {
 
 interface HtmlFileConfiguration {
     filename: string,           // Output filename, e.g. index.html. This path is relative to the out dir
-    entryPoints: string[],      // Entry points to inject into the created html file, e.g. ['src/index.jsx']. 
-                                // Multiple entryPoints are possible.
+    entryPoints?: string[],     // Entry points to inject into the created html file, e.g. ['src/index.jsx']. 
+                                // Multiple entryPoints are possible. Must supply entryPoints or outputs.
+    injectedOutputs?: string[], // Esbuild outputs to inject into the created html file, e.g. ['dist/auth.js']. 
+                                // Multiple outputs are possible. Must supply entryPoints or outputs.
     title?: string,             // title to inject into the head, will not be set if not specified
     htmlTemplate?: string,      // custom html document template string. If you omit a template, 
                                 // a default template will be used (see below)

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -4,7 +4,8 @@ export interface Configuration {
 }
 export interface HtmlFileConfiguration {
     filename: string;
-    entryPoints: string[];
+    entryPoints?: string[];
+    injectedOutputs?: string[];
     title?: string;
     htmlTemplate?: string;
     define?: Record<string, string>;

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -36,15 +36,24 @@ function escapeRegExp(text) {
 }
 const htmlPlugin = (configuration = { files: [], }) => {
     configuration.files = configuration.files.map((htmlFileConfiguration) => {
+        if (!htmlFileConfiguration.entryPoints && !htmlFileConfiguration.injectedOutputs) {
+            throw new Error('Must supply at least one of `entryPoints` or `injectedOutputs`.');
+        }
         return Object.assign({}, { findRelatedOutputFiles: false, findRelatedCssFiles: true }, htmlFileConfiguration); // Set default values
     });
     let logInfo = false;
     function collectEntrypoints(htmlFileConfiguration, metafile) {
-        const entryPoints = Object.entries((metafile === null || metafile === void 0 ? void 0 : metafile.outputs) || {}).filter(([, value]) => {
+        const entryPoints = Object.entries((metafile === null || metafile === void 0 ? void 0 : metafile.outputs) || {}).filter(([key, value]) => {
             if (!value.entryPoint) {
                 return false;
             }
-            return htmlFileConfiguration.entryPoints.includes(value.entryPoint);
+            if (htmlFileConfiguration.entryPoints && htmlFileConfiguration.entryPoints.includes(value.entryPoint)) {
+                return true;
+            }
+            else if (htmlFileConfiguration.injectedOutputs && htmlFileConfiguration.injectedOutputs.includes(key)) {
+                return true;
+            }
+            return false;
         }).map(outputData => {
             // Flatten the output, instead of returning an array, let's return an object that contains the path of the output file as path
             return { path: outputData[0], ...outputData[1] };


### PR DESCRIPTION
Adds a new option to be used instead of, or in addition to, `entryPoints`. If you have defined `output`s for the `esbuild` configuration, then you can use them to determine the injected asset instead of the `entryPoint`.