### PR TITLE
Template: don't call `lodashTemplate` if `define` param is undefined

### DIFF
--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -99,8 +99,13 @@ const htmlPlugin = (configuration = { files: [], }) => {
         const template = (htmlTemplate && fs_1.default.existsSync(htmlTemplate)
             ? await fs_1.default.promises.readFile(htmlTemplate)
             : htmlTemplate || '').toString();
-        const compiledTemplateFn = (0, lodash_template_1.default)(template || defaultHtmlTemplate);
-        return compiledTemplateFn({ define });
+        if (define === undefined) {
+            return template;
+        }
+        else {
+            const compiledTemplateFn = (0, lodash_template_1.default)(template || defaultHtmlTemplate);
+            return compiledTemplateFn({ define });
+        }
     }
     // use the same joinWithPublicPath function as esbuild:
     //  https://github.com/evanw/esbuild/blob/a1ff9d144cdb8d50ea2fa79a1d11f43d5bd5e2d8/internal/bundler/bundler.go#L533

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -96,14 +96,15 @@ const htmlPlugin = (configuration = { files: [], }) => {
         }
     }
     async function renderTemplate({ htmlTemplate, define }) {
-        const template = (htmlTemplate && fs_1.default.existsSync(htmlTemplate)
+        const customHtmlTemplate = (htmlTemplate && fs_1.default.existsSync(htmlTemplate)
             ? await fs_1.default.promises.readFile(htmlTemplate)
             : htmlTemplate || '').toString();
+        const template = customHtmlTemplate || defaultHtmlTemplate;
         if (define === undefined) {
             return template;
         }
         else {
-            const compiledTemplateFn = (0, lodash_template_1.default)(template || defaultHtmlTemplate);
+            const compiledTemplateFn = (0, lodash_template_1.default)(template);
             return compiledTemplateFn({ define });
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export interface HtmlFileConfiguration {
     /** @param findRelatedCssFiles Whether to find CSS files that are related to the entry points. */
     findRelatedCssFiles?: boolean,
     /**
-     * @deprecated Use findRelatedCssFiles instead. 
+     * @deprecated Use findRelatedCssFiles instead.
      * @param findRelatedOutputFiles Whether to find output files that are related to the entry points. */
     findRelatedOutputFiles?: boolean,
     /** @param inline Whether to inline the content of the js and css files. */
@@ -143,8 +143,13 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
         const template = (htmlTemplate && fs.existsSync(htmlTemplate)
             ? await fs.promises.readFile(htmlTemplate)
             : htmlTemplate || '').toString()
-        const compiledTemplateFn = lodashTemplate(template || defaultHtmlTemplate)
-        return compiledTemplateFn({ define })
+
+        if (define === undefined) {
+            return template
+        } else {
+            const compiledTemplateFn = lodashTemplate(template || defaultHtmlTemplate)
+            return compiledTemplateFn({ define })
+        }
     }
 
     // use the same joinWithPublicPath function as esbuild:
@@ -226,7 +231,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
                 // If not inlined, set the 'src' attribute as usual.
                 scriptTag.setAttribute('src', targetPath)
-                    
+
                 if (htmlFileConfiguration.scriptLoading === 'module') {
                     // If module, add type="module"
                     scriptTag.setAttribute('type', 'module')
@@ -249,7 +254,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
                     // no need to set any attributes
                     continue
-                } 
+                }
 
                 const linkTag = document.createElement('link')
                 linkTag.setAttribute('rel', 'stylesheet')

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,14 +140,16 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
     }
 
     async function renderTemplate({ htmlTemplate, define }: HtmlFileConfiguration) {
-        const template = (htmlTemplate && fs.existsSync(htmlTemplate)
+        const customHtmlTemplate = (htmlTemplate && fs.existsSync(htmlTemplate)
             ? await fs.promises.readFile(htmlTemplate)
             : htmlTemplate || '').toString()
+
+        const template = customHtmlTemplate || defaultHtmlTemplate
 
         if (define === undefined) {
             return template
         } else {
-            const compiledTemplateFn = lodashTemplate(template || defaultHtmlTemplate)
+            const compiledTemplateFn = lodashTemplate(template)
             return compiledTemplateFn({ define })
         }
     }


### PR DESCRIPTION
## Description

I attempt to use `esbuild-plugin-html` with custom HTML templates for different locales. HTML templates contain a script tag where the object with translation messages for react-intl is defined. Example:

```html
<script>
  globalThis["__intlMessages__"] = {"1d7f4940074ad8704abbaf70c1316258":"${amount} / 年"}
</script>
```
The problem is that translation message contain `$` character with a placeholder for a runtime value inside of curly braces. Example: `"${amount} / 年"` (it will be `$99 / 年` at runtime). `${amount}` is a legit target of lodash template function, but I got esbuild error because `amount` value is missing in `define` param object. I don't use `define` param in `esbuild-plugin-html` and I don't need to replace anything in my HTML templates.

Currently, it produces a build error:

```
/home/me/monorepo/node_modules/lodash.template/index.js:1550:11: ERROR: [plugin: esbuild-html-plugin] amount is not defined
    at failureErrorWithLog (/home/me/monorepo/node_modules/esbuild/lib/main.js:1649:15)
    at /home/me/monorepo/node_modules/esbuild/lib/main.js:1058:25
    at /home/me/monorepo/node_modules/esbuild/lib/main.js:1525:9 {
  errors: [
    {
      id: '',
      pluginName: 'esbuild-html-plugin',
      text: 'amount is not defined',
      location: {
        file: '/home/me/monorepo/node_modules/lodash.template/index.js',
        namespace: 'file',
        line: 1550,
        column: 11,
        length: 0,
        lineText: "    return Function(importsKeys, sourceURL + 'return ' + source)\n" +
          '    at eval (eval at <anonymous> (/home/me/monorepo/node_modules/lodash.template/index.js:1550:12), <anonymous>:8:10)\n' +
          '    at renderTemplate (/home/me/monorepo/node_modules/@craftamap/esbuild-plugin-html/lib/cjs/index.js:103:16)\n' +
          '    at async /home/me/monorepo/node_modules/@craftamap/esbuild-plugin-html/lib/cjs/index.js:246:46\n' +
          '    at async /home/me/monorepo/node_modules/esbuild/lib/main.js:1494:27',
        suggestion: ''
      },
      notes: [
        {
          text: 'This error came from the "onEnd" callback registered here:',
          location: [Object]
        }
      ],
      detail: 0
    }
  ],
```

## Solution
I propose to simply don't call `lodashTemplate` function if `define` param is undefined.

Another possible option is to introduce an extra param like `useLodashTemplate: bool` or something, but I think my suggestion is simpler and just works.

Overall, I think it's a good idea to avoid calling `lodashTemplate` function at all when it isn't needed as a performance optimization.