### PR TITLE
Use scriptLoading configuration option in inline scripts as well

### DIFF
--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -164,6 +164,15 @@ const htmlPlugin = (configuration = { files: [], }) => {
             };
             if (ext === '.js') {
                 const scriptTag = document.createElement('script');
+                if (htmlFileConfiguration.scriptLoading === "module") {
+                    // If module, add type="module"
+                    scriptTag.setAttribute("type", "module");
+                }
+                else if (!htmlFileConfiguration.scriptLoading ||
+                    htmlFileConfiguration.scriptLoading === "defer") {
+                    // if scriptLoading is unset, or defer, use defer
+                    scriptTag.setAttribute("defer", "");
+                }
                 // Check if the JavaScript should be inlined.
                 if (isInline()) {
                     logInfo && console.log('Inlining script', filepath);
@@ -176,14 +185,6 @@ const htmlPlugin = (configuration = { files: [], }) => {
                 }
                 // If not inlined, set the 'src' attribute as usual.
                 scriptTag.setAttribute('src', targetPath);
-                if (htmlFileConfiguration.scriptLoading === 'module') {
-                    // If module, add type="module"
-                    scriptTag.setAttribute('type', 'module');
-                }
-                else if (!htmlFileConfiguration.scriptLoading || htmlFileConfiguration.scriptLoading === 'defer') {
-                    // if scriptLoading is unset, or defer, use defer
-                    scriptTag.setAttribute('defer', '');
-                }
                 document.body.append(scriptTag);
             }
             else if (ext === '.css') {

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -168,8 +168,8 @@ const htmlPlugin = (configuration = { files: [], }) => {
                     // If module, add type="module"
                     scriptTag.setAttribute("type", "module");
                 }
-                else if (!htmlFileConfiguration.scriptLoading ||
-                    htmlFileConfiguration.scriptLoading === "defer") {
+                else if ((!htmlFileConfiguration.scriptLoading ||
+                    htmlFileConfiguration.scriptLoading === "defer") && !htmlFileConfiguration.inline) {
                     // if scriptLoading is unset, or defer, use defer
                     scriptTag.setAttribute("defer", "");
                 }

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -164,14 +164,13 @@ const htmlPlugin = (configuration = { files: [], }) => {
             };
             if (ext === '.js') {
                 const scriptTag = document.createElement('script');
-                if (htmlFileConfiguration.scriptLoading === "module") {
+                if (htmlFileConfiguration.scriptLoading === 'module') {
                     // If module, add type="module"
-                    scriptTag.setAttribute("type", "module");
+                    scriptTag.setAttribute('type', 'module');
                 }
-                else if ((!htmlFileConfiguration.scriptLoading ||
-                    htmlFileConfiguration.scriptLoading === "defer") && !htmlFileConfiguration.inline) {
-                    // if scriptLoading is unset, or defer, use defer
-                    scriptTag.setAttribute("defer", "");
+                else if (!htmlFileConfiguration.inline && (!htmlFileConfiguration.scriptLoading || htmlFileConfiguration.scriptLoading === 'defer')) {
+                    // if scriptLoading is unset or defer, use defer
+                    scriptTag.setAttribute('defer', '');
                 }
                 // Check if the JavaScript should be inlined.
                 if (isInline()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,15 +219,14 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
             if (ext === '.js') {
                 const scriptTag = document.createElement('script')
 
-                if (htmlFileConfiguration.scriptLoading === "module") {
-                  // If module, add type="module"
-                  scriptTag.setAttribute("type", "module");
+                if (htmlFileConfiguration.scriptLoading === 'module') {
+                    // If module, add type="module"
+                    scriptTag.setAttribute('type', 'module')
                 } else if (
-                  (!htmlFileConfiguration.scriptLoading ||
-                  htmlFileConfiguration.scriptLoading === "defer") && !htmlFileConfiguration.inline
+                    !htmlFileConfiguration.inline && (!htmlFileConfiguration.scriptLoading || htmlFileConfiguration.scriptLoading === 'defer')
                 ) {
-                  // if scriptLoading is unset, or defer, use defer
-                  scriptTag.setAttribute("defer", "");
+                    // if scriptLoading is unset or defer, use defer
+                    scriptTag.setAttribute('defer', '')
                 }
 
                 // Check if the JavaScript should be inlined.

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,13 +223,13 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
                   // If module, add type="module"
                   scriptTag.setAttribute("type", "module");
                 } else if (
-                  !htmlFileConfiguration.scriptLoading ||
-                  htmlFileConfiguration.scriptLoading === "defer"
+                  (!htmlFileConfiguration.scriptLoading ||
+                  htmlFileConfiguration.scriptLoading === "defer") && !htmlFileConfiguration.inline
                 ) {
                   // if scriptLoading is unset, or defer, use defer
                   scriptTag.setAttribute("defer", "");
                 }
-                
+
                 // Check if the JavaScript should be inlined.
                 if (isInline()) {
                     logInfo && console.log('Inlining script', filepath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
                     scriptTag.setAttribute(key, value)
                 })
             }
+
             document.body.append(scriptTag)
         }
         for (const outputFile of assets) {
@@ -217,6 +218,18 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
             if (ext === '.js') {
                 const scriptTag = document.createElement('script')
+
+                if (htmlFileConfiguration.scriptLoading === "module") {
+                  // If module, add type="module"
+                  scriptTag.setAttribute("type", "module");
+                } else if (
+                  !htmlFileConfiguration.scriptLoading ||
+                  htmlFileConfiguration.scriptLoading === "defer"
+                ) {
+                  // if scriptLoading is unset, or defer, use defer
+                  scriptTag.setAttribute("defer", "");
+                }
+                
                 // Check if the JavaScript should be inlined.
                 if (isInline()) {
                     logInfo && console.log('Inlining script', filepath)
@@ -234,14 +247,6 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
                 // If not inlined, set the 'src' attribute as usual.
                 scriptTag.setAttribute('src', targetPath)
-
-                if (htmlFileConfiguration.scriptLoading === 'module') {
-                    // If module, add type="module"
-                    scriptTag.setAttribute('type', 'module')
-                } else if (!htmlFileConfiguration.scriptLoading || htmlFileConfiguration.scriptLoading === 'defer') {
-                    // if scriptLoading is unset, or defer, use defer
-                    scriptTag.setAttribute('defer', '')
-                }
 
                 document.body.append(scriptTag)
             } else if (ext === '.css') {


### PR DESCRIPTION
When scripts are being inlined, scriptLoading configuration option does not have an effect and therefore a runtime error occur in scripts on load that do work when inline is false (type="module")


