### PR TITLE
feat!: disable es6-like string interpolation ${} when compiling templates

### DIFF
--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -100,13 +100,8 @@ const htmlPlugin = (configuration = { files: [], }) => {
             ? await fs_1.default.promises.readFile(htmlTemplate)
             : htmlTemplate || '').toString();
         const template = customHtmlTemplate || defaultHtmlTemplate;
-        if (define === undefined) {
-            return template;
-        }
-        else {
-            const compiledTemplateFn = (0, template_1.default)(template);
-            return compiledTemplateFn({ define });
-        }
+        const compiledTemplateFn = (0, template_1.default)(template, { interpolate: /<%=([\s\S]+?)%>/g });
+        return compiledTemplateFn({ define });
     }
     // use the same joinWithPublicPath function as esbuild:
     //  https://github.com/evanw/esbuild/blob/a1ff9d144cdb8d50ea2fa79a1d11f43d5bd5e2d8/internal/bundler/bundler.go#L533

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,12 +146,8 @@ export const htmlPlugin = (configuration: Configuration = { files: [], }): esbui
 
         const template = customHtmlTemplate || defaultHtmlTemplate
 
-        if (define === undefined) {
-            return template
-        } else {
-            const compiledTemplateFn = lodashTemplate(template)
-            return compiledTemplateFn({ define })
-        }
+        const compiledTemplateFn = lodashTemplate(template, { interpolate: /<%=([\s\S]+?)%>/g })
+        return compiledTemplateFn({ define })
     }
 
     // use the same joinWithPublicPath function as esbuild:


### PR DESCRIPTION
This patch disables using ${} in the html templates. This is mostly to avoid conflicts with the provided template that might use ${} in inline javascript natively.

This patch also reverts the changes of #46.
lodash.template is now always called. this is useful for when you want to use `process.env`.

Therefore, this change is breaking, as it removes ${}, but also always calls lodash again.

If this ever will be a problem, we can also add a configuration option to enable ${} manually again.

Fixes #60 
Fixes #57 
Fixes #48 
